### PR TITLE
A-785: Update `WORKSPACE` file

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,30 +1,48 @@
 workspace(name = "com_github_johnynek_bazel_deps")
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl",
-     "git_repository", "new_git_repository")
+load(
+    "@bazel_tools//tools/build_defs/repo:git.bzl",
+    "git_repository",
+    "new_git_repository",
+)
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive") 
+rules_scala_version = "ca5a7acff4ff630f68f58b8e01e8c25dbf908fb7"
 
-rules_scala_version="b537bddc58a77318b34165812a0311ef52806318"
 http_archive(
-             name = "io_bazel_rules_scala",
-             url = "https://github.com/bazelbuild/rules_scala/archive/%s.zip"%rules_scala_version,
-             type = "zip",
-             strip_prefix= "rules_scala-%s" % rules_scala_version
-             )
+    name = "io_bazel_rules_scala",
+    strip_prefix = "rules_scala-%s" % rules_scala_version,
+    type = "zip",
+    url = "https://github.com/bazelbuild/rules_scala/archive/%s.zip" % rules_scala_version,
+)
+
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "9510dd2afc29e7245e9e884336f848c8a6600a14ae726adb6befdb4f786f0be2",
+    strip_prefix = "protobuf-3.6.1.3",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.zip"],
+)
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
-scala_repositories(("2.12.7", {
-    "scala_compiler": "6e80ef4493127214d31631287a6789170bf6c9a771d6094acd8dc785e8970270",
-    "scala_library": "8f3dc6091db688464ad8b1ee6c7343d7aa5940d474ee8b90406c71e45dd74fc0",
-    "scala_reflect": "7427d7ee5771e8c36c1db5a09368fa3078f6eceb77d7c797a322a088c5dddb76"
-}))
+
+scala_repositories((
+    "2.12.7",
+    {
+        "scala_compiler": "6e80ef4493127214d31631287a6789170bf6c9a771d6094acd8dc785e8970270",
+        "scala_library": "8f3dc6091db688464ad8b1ee6c7343d7aa5940d474ee8b90406c71e45dd74fc0",
+        "scala_reflect": "7427d7ee5771e8c36c1db5a09368fa3078f6eceb77d7c797a322a088c5dddb76",
+    },
+))
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
+
 register_toolchains("//:scala_toolchain")
 
 load("//3rdparty:workspace.bzl", "maven_dependencies")
 
 maven_dependencies()
 
-bind(name = 'io_bazel_rules_scala/dependency/scalatest/scalatest', actual = '//3rdparty/jvm/org/scalatest')
+bind(
+    name = "io_bazel_rules_scala/dependency/scalatest/scalatest",
+    actual = "//3rdparty/jvm/org/scalatest",
+)


### PR DESCRIPTION
I had a build error on master code, so I can't check if my changes are logically correct.
However, @jtownson  could confirm that referring to the commit in this PR fixed his `deps` script in `decco`

## TWO NOTES
First, we have a reference to @marcesquerra's repository in the deps file of bazel-deps

Second, expanding on the build error, my output in master for bazel build is:
```
$ bazel build //...
INFO: SHA256 (https://github.com/bazelbuild/rules_scala/archive/b537bddc58a77318b34165812a0311ef52806318.zip) = 9269724ce33734be23ee1aa27f86b17ce469a0160d23f1eb81da4595e94ebca1
DEBUG: Rule 'io_bazel_rules_scala' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "9269724ce33734be23ee1aa27f86b17ce469a0160d23f1eb81da4595e94ebca1"
ERROR: /home/eze/Escritorio/IOHK/projects/bazel-deps/src/scala/com/github/johnynek/bazel_deps/maven/BUILD:1:1: no such package '3rdparty/jvm/io/circe': BUILD file not found on package path and referenced by '//src/scala/com/github/johnynek/bazel_deps/maven:maven'
ERROR: /home/eze/Escritorio/IOHK/projects/bazel-deps/src/scala/com/github/johnynek/bazel_deps/maven/BUILD:1:1: no such package '3rdparty/jvm/io/circe': BUILD file not found on package path and referenced by '//src/scala/com/github/johnynek/bazel_deps/maven:maven'
ERROR: /home/eze/Escritorio/IOHK/projects/bazel-deps/src/scala/com/github/johnynek/bazel_deps/maven/BUILD:1:1: no such package '3rdparty/jvm/org/scala_lang/modules': BUILD file not found on package path and referenced by '//src/scala/com/github/johnynek/bazel_deps/maven:maven'
ERROR: /home/eze/Escritorio/IOHK/projects/bazel-deps/src/scala/com/github/johnynek/bazel_deps/maven/BUILD:1:1: no such package '3rdparty/jvm/org/typelevel': BUILD file not found on package path and referenced by '//src/scala/com/github/johnynek/bazel_deps/maven:maven'
ERROR: Analysis of target '//src/scala/com/github/johnynek/bazel_deps/maven:maven' failed; build aborted: no such package '3rdparty/jvm/org/scala_lang/modules': BUILD file not found on package path
INFO: Elapsed time: 3.730s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (69 packages loaded, 162 targets configured)
```


In my branch after updating the `WORSPACE` file I get this:
```
$ bazel build //...
DEBUG: Rule 'io_bazel_rules_scala' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "5f1253fe108b2580427cedee92347d6b950cae1cab6b30e19da2ee1df2949905"
DEBUG: /home/eze/.cache/bazel/_bazel_eze/d858219e17a396a581b410c94905a4a5/external/io_bazel_rules_scala/scala/scala_maven_import_external.bzl:59:9: 'jar_sha256' is deprecated. Please use 'artifact_sha256'
ERROR: /home/eze/Escritorio/IOHK/projects/bazel-deps/src/scala/com/github/johnynek/bazel_deps/maven/BUILD:1:1: no such package '3rdparty/jvm/io/circe': BUILD file not found on package path and referenced by '//src/scala/com/github/johnynek/bazel_deps/maven:maven'
ERROR: /home/eze/Escritorio/IOHK/projects/bazel-deps/src/scala/com/github/johnynek/bazel_deps/maven/BUILD:1:1: no such package '3rdparty/jvm/io/circe': BUILD file not found on package path and referenced by '//src/scala/com/github/johnynek/bazel_deps/maven:maven'
ERROR: /home/eze/Escritorio/IOHK/projects/bazel-deps/src/scala/com/github/johnynek/bazel_deps/maven/BUILD:1:1: no such package '3rdparty/jvm/org/scala_lang/modules': BUILD file not found on package path and referenced by '//src/scala/com/github/johnynek/bazel_deps/maven:maven'
ERROR: /home/eze/Escritorio/IOHK/projects/bazel-deps/src/scala/com/github/johnynek/bazel_deps/maven/BUILD:1:1: no such package '3rdparty/jvm/org/typelevel': BUILD file not found on package path and referenced by '//src/scala/com/github/johnynek/bazel_deps/maven:maven'
ERROR: Analysis of target '//src/scala/com/github/johnynek/bazel_deps/maven:maven' failed; build aborted: no such package '3rdparty/jvm/org/scala_lang/modules': BUILD file not found on package path
INFO: Elapsed time: 0.166s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (1 packages loaded, 1 target configured)
```